### PR TITLE
Pull build dependencies for reproducible build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:latest AS builder
 COPY . $GOPATH/src/mypackage/myapp/
 WORKDIR $GOPATH/src/mypackage/myapp/
+RUN apt-get update && apt-get install -y go-dep
+RUN CGO_ENABLED=0 GOOS=linux dep ensure
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /mutating-dns-webhook-server .
 
 FROM alpine:latest

--- a/main.go
+++ b/main.go
@@ -24,12 +24,12 @@ func main() {
 	
 	dnsConfig, err := loadConfig(parameters.dnsCfgFile)
 	if err != nil {
-		glog.Errorf("Filed to load configuration: %v", err)
+		glog.Errorf("Failed to load configuration: %v", err)
 	}
 	
 	pair, err := tls.LoadX509KeyPair(parameters.certFile, parameters.keyFile)
 	if err != nil {
-		glog.Errorf("Filed to load key pair: %v", err)
+		glog.Errorf("Failed to load key pair: %v", err)
 	}
 	
 	whsvr := &WebhookServer {
@@ -49,7 +49,7 @@ func main() {
 	// start webhook server in new rountine
 	go func() {
 		if err := whsvr.server.ListenAndServeTLS("", ""); err != nil {
-			glog.Errorf("Filed to listen and serve webhook server: %v", err)
+			glog.Errorf("Failed to listen and serve webhook server: %v", err)
 		}
 	}()
 	


### PR DESCRIPTION
Hi there,

it seems to me that your Dockerfile assumes that all the go dependencies are already pulled to the local directory of your development machine where you run the docker build. Since this is not the case for me, I had to add a line in the dockerfile to fetch the dependencies, so I thought I should let you know.

If you are curious, I've used your injector to solve this problem in one of my clusters: 

https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts

My UDP request were failing randomly but adding single-request or use-vc to /etc/resolv.conf solved the problem, although use-vc was much faster. I thought about writing a mutator when I found yours. Thank you for sharing!